### PR TITLE
Manage private keys separately during encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Zippy is not intended for production use, but as a learning tool for custom enco
   Each unique character in the input is assigned a 2-digit index as it appears.
 - **Modular Exponentiation:**  
   Each index is obfuscated using modular exponentiation (`y = x^pub mod tot`) for basic encryption.
-- **File Output:**  
-  The dictionary and encoded data are saved to `encoded.txt`.
-- **Decoding:**  
-  The `Unzippy.py` script reverses the process using the private key.
+- **File Output:**
+  The encoded data for each round is saved to `encoded_output.txt`, while private keys are stored separately in `private_keys.json`.
+- **Decoding:**
+  The `Unzippy.py` script reverses the process using private keys stored separately in `private_keys.json`.
 
 ---
 
@@ -27,17 +27,17 @@ Zippy is not intended for production use, but as a learning tool for custom enco
    Reads the contents of `texsample.txt`.
 2. **Build Dictionary:**  
    Assigns each unique character a 2-digit index in order of appearance.
-3. **Encode:**  
+3. **Encode:**
    Replaces each character with its index, then encodes each 2-digit index using modular exponentiation.
-4. **Save:**  
-   Writes the dictionary and encoded string to `encoded.txt`.
+4. **Save:**
+   Writes round metadata to `encoded_output.txt` and saves the private keys to `private_keys.json`.
 
 ### Decompression (`Unzippy.py`)
 
-1. **Read Encoded File:**  
-   Loads the dictionary and encoded string from `encoded.txt`.
-2. **Decode:**  
-   Uses the private key to reverse the modular exponentiation and recover the original indices.
+1. **Read Encoded File:**
+   Loads the dictionary and encoded string from `encoded_output.txt`.
+2. **Decode:**
+   Uses the private keys supplied by the caller to reverse the modular exponentiation and recover the original indices.
 3. **Reconstruct:**  
    Maps indices back to characters using the dictionary and prints the original text.
 
@@ -52,7 +52,7 @@ python Zipper.py
 ```
 
 - Input: `texsample.txt`
-- Output: `encoded.txt` (dictionary on the first line, encoded string on the second)
+- Output: `encoded_output.txt` and `private_keys.json`
 
 ### Decompress
 
@@ -60,7 +60,7 @@ python Zipper.py
 python Unzippy.py
 ```
 
-- Input: `encoded.txt`
+- Input: `encoded_output.txt` and `private_keys.json`
 - Output: Prints the reconstructed original text to the terminal
 
 ---
@@ -72,7 +72,7 @@ python Unzippy.py
 hello world
 ```
 
-**Output (`encoded.txt`):**
+**Output (`encoded_output.txt`):**
 ```
 h00e01l02o03 04w05r06d07
 0001020203044053056032037
@@ -87,14 +87,15 @@ Zippy/
 ├── Zipper.py
 ├── Unzippy.py
 ├── texsample.txt
-├── encoded.txt
+├── encoded_output.txt
+├── private_keys.json
 ```
 
 ---
 
 ## Notes
 
-- The keys (`tot`, `pub`, `pri`) are hardcoded for demonstration.
+- The private keys are saved to `private_keys.json` and must be supplied during decoding.
 - The encoding is not cryptographically secure.
 - For educational and experimental use only.
 

--- a/Unzippy.py
+++ b/Unzippy.py
@@ -46,31 +46,44 @@ def single_round_decode(encoded_input_str, tot, pri, chunk_size, original_indice
     decoded_indices_str = decoded_indices_str[:original_indices_len] # Remove padding
     return decoded_indices_str
 
-def multi_round_decode():
+def multi_round_decode(private_keys):
     with open("encoded_output.txt", "r") as f:
         all_round_data = json.load(f)
+
+    if len(private_keys) != len(all_round_data):
+        raise ValueError("Number of private keys must match number of encoding rounds")
 
     current_decoded_indices_str = ""
 
     # Iterate through rounds in reverse order
     for i in range(len(all_round_data) - 1, -1, -1):
         round_data = all_round_data[i]
-        
+
         tot = round_data["tot"]
-        pri = round_data["pri"]
+        pri = private_keys[i]
         chunk_size = round_data["chunk_size"]
         original_indices_len = round_data["original_indices_len"]
-        salt_length = round_data["salt_length"]
-        is_obfuscated = round_data["is_obfuscated"]
 
-        if i == len(all_round_data) - 1: # Last round in the encoding process (first to decode)
+        if i == len(all_round_data) - 1:  # Last round in the encoding process (first to decode)
             encoded_str_for_this_round = round_data["encoded_indices"]
+            salt_length = round_data["salt_length"]
+            is_obfuscated = round_data["is_obfuscated"]
         else:
-            encoded_str_for_this_round = current_decoded_indices_str # Output of previous decode is input for this decode
+            encoded_str_for_this_round = current_decoded_indices_str  # Output of previous decode is input for this decode
+            salt_length = 0
+            is_obfuscated = False
 
-        current_decoded_indices_str = single_round_decode(encoded_str_for_this_round, tot, pri, chunk_size, original_indices_len, salt_length, is_obfuscated)
+        current_decoded_indices_str = single_round_decode(
+            encoded_str_for_this_round,
+            tot,
+            pri,
+            chunk_size,
+            original_indices_len,
+            salt_length,
+            is_obfuscated,
+        )
 
-        if i == 0: # First round in the encoding process (last to decode)
+        if i == 0:  # First round in the encoding process (last to decode)
             iv_b64 = round_data["iv"]
             encrypted_dict_b64 = round_data["encrypted_dict"]
 
@@ -85,7 +98,7 @@ def multi_round_decode():
 
             # Now map indices back to chars
             output = []
-            for j in range(0, len(current_decoded_indices_str), 2): # Iterate by 2 digits for each character index
+            for j in range(0, len(current_decoded_indices_str), 2):  # Iterate by 2 digits for each character index
                 idx = current_decoded_indices_str[j:j+2]
                 if idx in dictionary:
                     output.append(dictionary[idx])
@@ -94,5 +107,7 @@ def multi_round_decode():
             return ''.join(output)
 
 if __name__ == "__main__":
-    decoded_text = multi_round_decode()
+    with open("private_keys.json", "r") as f:
+        private_keys = json.load(f)
+    decoded_text = multi_round_decode(private_keys)
     print(decoded_text)

--- a/Zipper.py
+++ b/Zipper.py
@@ -65,19 +65,27 @@ def single_round_rsa_encode(input_data, tot, pub, chunk_size=2, is_first_round=T
 
 def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, obfuscate_output=True):
     all_round_data = []
-    current_input_for_next_round = text # This will be the raw data for the next round
+    private_keys = []
+    current_input_for_next_round = text  # This will be the raw data for the next round
 
     for i in range(num_rounds):
-        tot, pub, pri = generate_keys() # New keys for each round
-        
+        tot, pub, pri = generate_keys()  # New keys for each round
+
         # Encode the current input using RSA
-        round_rsa_data = single_round_rsa_encode(current_input_for_next_round, tot, pub, initial_chunk_size, is_first_round=(i == 0), pri_key_for_shuffle=pri)
-        
+        round_rsa_data = single_round_rsa_encode(
+            current_input_for_next_round,
+            tot,
+            pub,
+            initial_chunk_size,
+            is_first_round=(i == 0),
+            pri_key_for_shuffle=pri,
+        )
+
         encoded_str_raw = round_rsa_data["encoded_indices_raw"]
 
         # Add salt/nonce
         if salt_length > 0:
-            salt = ''.join(random.choices('0123456789', k=salt_length)) # Random digits as salt
+            salt = ''.join(random.choices('0123456789', k=salt_length))  # Random digits as salt
             encoded_str_with_salt = encoded_str_raw + salt
         else:
             encoded_str_with_salt = encoded_str_raw
@@ -88,9 +96,9 @@ def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, ob
             final_encoded_bytes = base64.urlsafe_b64encode(compressed_encoded_str)
             final_encoded_str = final_encoded_bytes.decode('utf-8')
         else:
-            final_encoded_str = encoded_str_raw # Store raw if not obfuscating
+            final_encoded_str = encoded_str_raw  # Store raw if not obfuscating
 
-        # Store all data for the round
+        # Store all data for the round except the private key
         round_data = {
             "iv": round_rsa_data["iv"],
             "encrypted_dict": round_rsa_data["encrypted_dict"],
@@ -98,12 +106,12 @@ def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, ob
             "original_indices_len": round_rsa_data["original_indices_len"],
             "tot": tot,
             "pub": pub,
-            "pri": pri, # Store pri for decoding
             "chunk_size": initial_chunk_size,
             "salt_length": salt_length,
-            "is_obfuscated": obfuscate_output
+            "is_obfuscated": obfuscate_output,
         }
         all_round_data.append(round_data)
+        private_keys.append(pri)
 
         # Prepare input for the next round: it's the raw encoded indices from this round
         current_input_for_next_round = encoded_str_raw
@@ -111,6 +119,12 @@ def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, ob
     # Store all round data in a single file
     with open("encoded_output.txt", "w") as f:
         f.write(json.dumps(all_round_data, indent=4))
+
+    # Store private keys separately for the caller
+    with open("private_keys.json", "w") as f:
+        json.dump(private_keys, f)
+
+    return private_keys
 
 if __name__ == "__main__":
     with open("texsample.txt", "r") as f:


### PR DESCRIPTION
## Summary
- Stop embedding private keys in round metadata and write them to `private_keys.json`
- Update decoder to require caller-provided private keys and adjust round handling
- Document key management and new decode process

## Testing
- `pytest -q`
- `python Unzippy.py > /tmp/unzip.log 2>&1 && cat /tmp/unzip.log`


------
https://chatgpt.com/codex/tasks/task_e_68bf7be097d48333972cd752b765765b