### PR TITLE
Use secure randomness for key generation and salting

### DIFF
--- a/KeyGenerator.py
+++ b/KeyGenerator.py
@@ -1,4 +1,4 @@
-import random
+from Crypto.Random import random
 
 def is_prime(n, k=5):
     """Miller-Rabin primality test."""
@@ -32,7 +32,9 @@ def generate_prime(bits):
     """Generate a prime number with a given number of bits."""
     while True:
         p = random.getrandbits(bits)
-        if p % 2 != 0 and is_prime(p):
+        # Ensure the candidate has the correct bit length and is odd
+        p |= (1 << (bits - 1)) | 1
+        if p % 2 != 0 and is_prime(p) and p.bit_length() == bits:
             return p
 
 def gcd(a, b):
@@ -54,6 +56,9 @@ def mod_inverse(a, m):
 
 def generate_keys(bits=16):
     """Generate public and private keys."""
+    if bits < 16:
+        raise ValueError("bits must be at least 16 to ensure minimal entropy")
+
     p = generate_prime(bits)
     q = generate_prime(bits)
     tot = p * q

--- a/Zipper.py
+++ b/Zipper.py
@@ -1,12 +1,38 @@
-import random
 import hashlib
 import json
 import zlib
-from KeyGenerator import generate_keys
+import base64
+import math
+import secrets
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from Crypto.Random import get_random_bytes
-import base64
+from Crypto.Random import random as crypto_random
+from KeyGenerator import generate_keys
+
+
+def _secure_deterministic_prng(seed: bytes) -> crypto_random.StrongRandom:
+    """Create a cryptographically secure deterministic PRNG.
+
+    The generator is seeded with ``seed`` and produces reproducible output by
+    deriving random bytes from SHA-256 in counter mode.  The resulting PRNG
+    exposes the same interface as ``random.Random`` but uses strong randomness
+    internally.
+    """
+
+    seed_hash = hashlib.sha256(seed).digest()
+    counter = 0
+
+    def randfunc(n: int) -> bytes:
+        nonlocal counter
+        output = b""
+        while len(output) < n:
+            ctr_bytes = counter.to_bytes(16, "big")
+            output += hashlib.sha256(seed_hash + ctr_bytes).digest()
+            counter += 1
+        return output[:n]
+
+    return crypto_random.StrongRandom(randfunc=randfunc)
 
 def single_round_rsa_encode(input_data, tot, pub, chunk_size=2, is_first_round=True, pri_key_for_shuffle=None):
     dict_str = ""
@@ -15,9 +41,9 @@ def single_round_rsa_encode(input_data, tot, pub, chunk_size=2, is_first_round=T
     original_indices_str = ""
 
     if is_first_round:
-        # Create a seeded random number generator for deterministic shuffle
-        seed = int(hashlib.sha256(str(pri_key_for_shuffle).encode()).hexdigest(), 16)
-        seeded_random = random.Random(seed)
+        # Create a seeded cryptographically secure PRNG for deterministic shuffle
+        seed_bytes = str(pri_key_for_shuffle).encode()
+        seeded_random = _secure_deterministic_prng(seed_bytes)
 
         unique_chars = sorted(list(set(input_data)))
         seeded_random.shuffle(unique_chars)
@@ -77,7 +103,10 @@ def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, ob
 
         # Add salt/nonce
         if salt_length > 0:
-            salt = ''.join(random.choices('0123456789', k=salt_length)) # Random digits as salt
+            entropy = salt_length * math.log2(10)
+            if entropy < 32:
+                raise ValueError("Salt length must provide at least 32 bits of entropy")
+            salt = ''.join(secrets.choice('0123456789') for _ in range(salt_length))
             encoded_str_with_salt = encoded_str_raw + salt
         else:
             encoded_str_with_salt = encoded_str_raw


### PR DESCRIPTION
## Summary
- Replace Python's `random` usage with `secrets` and `Crypto.Random` for cryptographic operations.
- Add deterministic secure PRNG for dictionary shuffling and validate salt entropy.
- Enforce minimal key size and ensure generated primes have full bit length.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf7bde929883339229bd8bf4fe61e1