### PR TITLE
Increase default RSA key size to 2048 bits

### DIFF
--- a/KeyGenerator.py
+++ b/KeyGenerator.py
@@ -52,8 +52,13 @@ def mod_inverse(a, m):
         x1 += m0
     return x1
 
-def generate_keys(bits=16):
-    """Generate public and private keys."""
+def generate_keys(bits=2048):
+    """Generate public and private keys.
+
+    Args:
+        bits (int): Bit length of the primes to generate. Defaults to 2048,
+            producing an RSA modulus of roughly 4096 bits.
+    """
     p = generate_prime(bits)
     q = generate_prime(bits)
     tot = p * q
@@ -71,7 +76,7 @@ def generate_keys(bits=16):
     return (tot, pub, pri)
 
 if __name__ == '__main__':
-    tot, pub, pri = generate_keys(1024)
+    tot, pub, pri = generate_keys()
     print(f"tot={tot}")
     print(f"pub={pub}")
     print(f"pri={pri}")

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Zippy/
 
 ## Notes
 
-- The keys (`tot`, `pub`, `pri`) are hardcoded for demonstration.
+- Keys are generated with 2048-bit primes by default, producing large RSA moduli.
 - The encoding is not cryptographically secure.
 - For educational and experimental use only.
 
 ---
 
-**Author:**  
+**Author:**
 [Your Name Here]

--- a/Zipper.py
+++ b/Zipper.py
@@ -68,7 +68,7 @@ def multi_round_encode(text, num_rounds, initial_chunk_size=2, salt_length=0, ob
     current_input_for_next_round = text # This will be the raw data for the next round
 
     for i in range(num_rounds):
-        tot, pub, pri = generate_keys() # New keys for each round
+        tot, pub, pri = generate_keys() # New 2048-bit keys for each round
         
         # Encode the current input using RSA
         round_rsa_data = single_round_rsa_encode(current_input_for_next_round, tot, pub, initial_chunk_size, is_first_round=(i == 0), pri_key_for_shuffle=pri)


### PR DESCRIPTION
## Summary
- Default `generate_keys` now uses 2048-bit primes and updated docstring
- Document 2048-bit key generation and note large key default in Zipper
- Add README note describing new 2048-bit default

## Testing
- `pytest -q`
- `python -m py_compile KeyGenerator.py Zipper.py Unzippy.py`
- Generated 2048-bit keys and encoded sample text to verify block sizing


------
https://chatgpt.com/codex/tasks/task_e_68bf7bdd33a08333bdd8932c7c0d9c0a